### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - git@github.com:mesosphere/pod-ca-trust.git//deploy?ref=v0.1.0 # <-- set the version here
+  - git@github.com:mesosphere/pod-ca-trust.git//deploy?ref=v0.2.0 # <-- set the version here
 
 # configure the installation namespace
 namespace: pod-ca-trust


### PR DESCRIPTION
Bump the version to 0.2.0 as the CA certificate is now stored in a ConfigMap and not a Secret

Hit this using the example docs:
```
[tony@rockyadmin test]$ kubectl logs -n pod-ca-trust pod-ca-trust-webhook-58767bfb-vwz9m
F0131 20:30:58.876934       1 main.go:25] secrets "ca-cert" not found
```